### PR TITLE
fix the deprecation warning for DEPRECATION WARNING: ActiveRecord::Ba…

### DIFF
--- a/lib/activerecord-refresh_connection/active_record/connection_adapters/refresh_connection_management.rb
+++ b/lib/activerecord-refresh_connection/active_record/connection_adapters/refresh_connection_management.rb
@@ -39,7 +39,7 @@ module ActiveRecord
 
         @clear_connections =
           if ar_version >= "6.1"
-            if ActiveRecord::Base.legacy_connection_handling
+            if ActiveRecord.legacy_connection_handling
               :clear_legacy_compatible_connections
             else
               :clear_multi_db_connections


### PR DESCRIPTION
Fix the deprecation warning for :
```
DEPRECATION WARNING: ActiveRecord::Base.legacy_connection_handling is deprecated and will be removed in Rails 7.1.
Use `ActiveRecord.legacy_connection_handling` instead.
 (called from resolve_clear_connections at /home/runner/work/fril_web/fril_web/vendor/bundle/ruby/3.0.0/bundler/gems/activerecord-refresh_connection-c15b57fa95e6/lib/activerecord-refresh_connection/active_record/connection_adapters/refresh_connection_management.rb:42)
```